### PR TITLE
Add Biosiglib release propagation workflow

### DIFF
--- a/.github/workflows/propagate-biosiglib.yml
+++ b/.github/workflows/propagate-biosiglib.yml
@@ -1,0 +1,180 @@
+name: Propagate Biosiglib Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      biosiglib_release:
+        description: "Biosiglib release tag, e.g. v0.1.0"
+        required: true
+        type: string
+      biosiglib_commit:
+        description: "Biosiglib release target commit SHA"
+        required: true
+        type: string
+  repository_dispatch:
+    types: [biosiglib-release]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  propagate:
+    runs-on: ubuntu-latest
+    env:
+      BIOSIGLIB_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.biosiglib_release || github.event.client_payload.release }}
+      BIOSIGLIB_COMMIT: ${{ github.event_name == 'workflow_dispatch' && inputs.biosiglib_commit || github.event.client_payload.commit }}
+      BIOSIGLIB_ROOT: ${{ github.workspace }}/biosiglib
+
+    steps:
+      - name: Check out Biosigmat
+        uses: actions/checkout@v4
+        with:
+          path: biosigmat
+
+      - name: Validate propagation inputs
+        shell: bash
+        run: |
+          if [[ ! "$BIOSIGLIB_RELEASE" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Biosiglib release must match vMAJOR.MINOR.PATCH: $BIOSIGLIB_RELEASE" >&2
+            exit 1
+          fi
+          if [[ ! "$BIOSIGLIB_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Biosiglib commit must be a lowercase 40-character SHA: $BIOSIGLIB_COMMIT" >&2
+            exit 1
+          fi
+
+      - name: Check out Biosiglib
+        uses: actions/checkout@v4
+        with:
+          repository: BSICoS/biosiglib
+          ref: ${{ env.BIOSIGLIB_COMMIT }}
+          path: biosiglib
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify Biosiglib release
+        shell: bash
+        run: |
+          actual_commit="$(git -C biosiglib rev-parse HEAD)"
+          release_commit="$(git -C biosiglib rev-list -n 1 "$BIOSIGLIB_RELEASE")"
+          if [[ "$actual_commit" != "$BIOSIGLIB_COMMIT" ]]; then
+            echo "Biosiglib checkout mismatch: expected $BIOSIGLIB_COMMIT, got $actual_commit" >&2
+            exit 1
+          fi
+          if [[ "$release_commit" != "$BIOSIGLIB_COMMIT" ]]; then
+            echo "Release $BIOSIGLIB_RELEASE points to $release_commit, not $BIOSIGLIB_COMMIT" >&2
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: biosiglib/requirements-dev.txt
+
+      - name: Install Biosiglib validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r biosiglib/requirements-dev.txt
+
+      - name: Update conformance manifest
+        id: manifest-update
+        working-directory: biosigmat
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path("conformance.json")
+          manifest = json.loads(path.read_text(encoding="utf-8"))
+          release_tag = os.environ["BIOSIGLIB_RELEASE"]
+          commit = os.environ["BIOSIGLIB_COMMIT"]
+
+          manifest["biosiglib"]["release"] = release_tag.removeprefix("v")
+          manifest["biosiglib"]["commit"] = commit
+          manifest["$schema"] = re.sub(
+              r"/[0-9a-fA-F]{40}/",
+              f"/{commit}/",
+              manifest["$schema"],
+              count=1,
+          )
+
+          statuses = ", ".join(
+              f"{specification_id}: {entry['status']}"
+              for specification_id, entry in manifest["specifications"].items()
+          )
+          path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              print(f"manifest-statuses={statuses}", file=output)
+          PY
+          git diff -- conformance.json
+
+      - name: Validate conformance manifest
+        working-directory: biosigmat
+        run: python ../biosiglib/tools/validate_specs.py --manifest conformance.json
+
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: R2025a
+          cache: true
+          products: |
+            MATLAB
+            Signal_Processing_Toolbox
+            Curve_Fitting_Toolbox
+
+      - name: Run tdmetrics conformance tests
+        uses: matlab-actions/run-command@v2
+        with:
+          command: cd('biosigmat'); addpath('scripts/local'); runTests('hrv/tdmetrics')
+
+      - name: Run pantompkins conformance tests
+        uses: matlab-actions/run-command@v2
+        with:
+          command: cd('biosigmat'); addpath('scripts/local'); runTests('ecg/pantompkins')
+
+      - name: Run full MATLAB suite
+        uses: matlab-actions/run-command@v2
+        with:
+          command: cd('biosigmat'); addpath('scripts/local'); runTests
+
+      - name: Check whitespace
+        working-directory: biosigmat
+        run: git diff --check
+
+      - name: Detect manifest change
+        id: manifest-change
+        working-directory: biosigmat
+        shell: bash
+        run: |
+          if git diff --quiet -- conformance.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "conformance.json already pins $BIOSIGLIB_RELEASE at $BIOSIGLIB_COMMIT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open propagation pull request
+        if: steps.manifest-change.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: biosigmat
+          add-paths: conformance.json
+          commit-message: Propagate Biosiglib ${{ env.BIOSIGLIB_RELEASE }}
+          branch: chore/biosiglib-${{ env.BIOSIGLIB_RELEASE }}
+          delete-branch: true
+          base: main
+          title: Propagate Biosiglib ${{ env.BIOSIGLIB_RELEASE }}
+          body: |
+            Propagates a validated Biosiglib release into Biosigmat.
+
+            - Biosiglib release tag: `${{ env.BIOSIGLIB_RELEASE }}`
+            - Biosiglib commit: `${{ env.BIOSIGLIB_COMMIT }}`
+            - Manifest statuses: ${{ steps.manifest-update.outputs.manifest-statuses }}
+            - Validation: external manifest, `tdmetricsTest`, `pantompkinsTest`, full MATLAB suite, and `git diff --check` passed.
+            - Shared fixtures and conformance cases were consumed from Biosiglib and were not copied into Biosigmat.


### PR DESCRIPTION
Implements #25.

Adds manual and repository-dispatch propagation for Biosiglib releases. The workflow verifies the tag/commit pair, updates only conformance.json, preserves specification statuses, validates against the checked-out Biosiglib, runs targeted and full MATLAB tests, checks whitespace, and opens a propagation PR when the manifest changes.

Local smoke-equivalent validation with v0.1.0 / 1d3b019a5e882c2c302f593bfd4f7beeb01ea285:
- Biosiglib external manifest validation: passed
- tdmetricsTest: 6/6 passed
- pantompkinsTest: 11/11 passed
- full MATLAB suite: 149/149 passed
- git diff --check: passed

No Biosiglib fixtures or conformance cases are copied.