### PR TITLE
Align tdmetrics with Biosiglib v0.2.1

### DIFF
--- a/conformance.json
+++ b/conformance.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/BSICoS/biosiglib/e0eb2ba229a51254603f7592bc76eea0c5f8c9fd/schemas/implementation-manifest.schema.json",
+  "$schema": "https://raw.githubusercontent.com/BSICoS/biosiglib/9322c84207eb1aeb6fedac6839bd1b1a71494bc2/schemas/implementation-manifest.schema.json",
   "implementation": {
     "name": "biosigmat",
     "language": "MATLAB",
@@ -7,8 +7,8 @@
   },
   "biosiglib": {
     "repository": "https://github.com/BSICoS/biosiglib",
-    "commit": "e0eb2ba229a51254603f7592bc76eea0c5f8c9fd",
-    "release": "0.1.1"
+    "commit": "9322c84207eb1aeb6fedac6839bd1b1a71494bc2",
+    "release": "0.2.1"
   },
   "specifications": {
     "hrv.tdmetrics": {

--- a/src/hrv/tdmetrics.m
+++ b/src/hrv/tdmetrics.m
@@ -33,13 +33,13 @@ parse(parser, dtk);
 dtk = parser.Results.dtk(:);
 
 if any(isinf(dtk)) || any(dtk(~isnan(dtk)) <= 0)
-    error('biosigmat:TdmetricsInvalidInterval', ...
+    error('tdmetrics:InvalidInterval', ...
         'DTK must contain positive finite intervals or NaN markers.');
 end
 
 validDtk = dtk(~isnan(dtk));
 if numel(validDtk) < 2
-    error('biosigmat:TdmetricsInsufficientIntervals', ...
+    error('tdmetrics:InsufficientIntervals', ...
         'DTK must contain at least two valid intervals.');
 end
 

--- a/src/hrv/tdmetrics.m
+++ b/src/hrv/tdmetrics.m
@@ -1,60 +1,33 @@
 function metrics = tdmetrics(dtk)
 % TDMETRICS Compute standard time-domain indices for heart rate variability analysis.
-%
-%   METRICS = TDMETRICS(DTK) computes standard time-domain metrics used in heart rate
-%   variability (HRV) analysis from interval series (DTK). METRICS is a structure
-%   containing the following time-domain metrics:
-%     MHR   - Mean heart rate (beats/min)
-%     SDNN  - Standard deviation of normal-to-normal (NN) intervals (ms)
-%     SDSD  - Standard deviation of differences between adjacent NN intervals (ms)
-%     RMSSD - Root mean square of successive differences of NN intervals (ms)
-%     PNN50 - Proportion of interval differences > 50ms with respect to all NN intervals (%)
-%
-%   Example:
-%     % Compute time domain metrics from R-R interval series
-%     load('ecg_data.mat'); % Load ECG data
-%     rpeaks = pantompkins(ecg, fs); % Detect R-peaks
-%     dtk = diff(rpeaks); % Compute R-R intervals
-%     metrics = tdmetrics(dtk);
-%
-%     % Display results
-%     fprintf('Mean HR: %.1f bpm\n', metrics.mhr);
-%     fprintf('SDNN: %.1f ms\n', metrics.sdnn);
-%     fprintf('RMSSD: %.1f ms\n', metrics.rmssd);
-%     fprintf('SDSD: %.1f ms\n', metrics.sdsd);
-%     fprintf('pNN50: %.1f %%\n', metrics.pNN50);
-%
-%   See also PANTOMPKINS
 
-
-% Check number of input and output arguments
 narginchk(1, 1);
 nargoutchk(0, 1);
 
-% Parse and validate inputs
 parser = inputParser;
 parser.FunctionName = 'tdmetrics';
-addRequired(parser, 'tk', @(x) isnumeric(x) && isvector(x) && ~isempty(x));
-
+addRequired(parser, 'dtk', @(x) isnumeric(x) && isvector(x) && ~isempty(x));
 parse(parser, dtk);
 
-dtk = parser.Results.tk(:);
+dtk = parser.Results.dtk(:);
 
-% Compute successive differences
-ddtk = diff(dtk);
+if any(isinf(dtk)) || any(dtk(~isnan(dtk)) <= 0)
+    error('biosigmat:TdmetricsInvalidInterval', ...
+        'DTK must contain positive finite intervals or NaN markers.');
+end
 
-% Compute time-domain metrics
-mhr = 60 / mean(dtk, 'omitnan');
-sdnn = 1000 * std(dtk, 'omitnan');
-rmssd = 1000 * norm(ddtk(~isnan(ddtk))) / sqrt(length(ddtk(~isnan(ddtk))));
-sdsd = 1000 * std(ddtk, 'omitnan');
-pNN50 = 100 * (sum(abs(ddtk) > 0.05)) / sum(~isnan(ddtk));
+validDtk = dtk(~isnan(dtk));
+if numel(validDtk) < 2
+    error('biosigmat:TdmetricsInsufficientIntervals', ...
+        'DTK must contain at least two valid intervals.');
+end
 
-% Construct output structure
-metrics.mhr = mhr;
-metrics.sdnn = sdnn;
-metrics.sdsd = sdsd;
-metrics.rmssd = rmssd;
-metrics.pNN50 = pNN50;
+ddtk = diff(validDtk);
+
+metrics.mhr = 60 / mean(validDtk);
+metrics.sdnn = 1000 * std(validDtk);
+metrics.sdsd = 1000 * std(ddtk);
+metrics.rmssd = 1000 * norm(ddtk) / sqrt(length(ddtk));
+metrics.pNN50 = 100 * sum(abs(ddtk) > 0.05) / length(ddtk);
 
 end

--- a/src/hrv/tdmetrics.m
+++ b/src/hrv/tdmetrics.m
@@ -1,5 +1,26 @@
 function metrics = tdmetrics(dtk)
-% TDMETRICS Compute standard time-domain indices for heart rate variability analysis.
+% TDMETRICS Compute time-domain HRV metrics from interval series.
+%
+%   METRICS = TDMETRICS(DTK) computes standard time-domain heart-rate
+%   variability metrics from the interval series DTK, expressed in seconds.
+%
+%   DTK must be a non-empty numeric vector. Positive finite values are treated
+%   as valid intervals. NaN values are allowed as missing-interval markers and
+%   are omitted before computing the metrics. Inf, zero and negative values are
+%   rejected.
+%
+%   METRICS is a structure with fields:
+%     mhr   - Mean heart rate in beats per minute.
+%     sdnn  - Standard deviation of intervals in milliseconds.
+%     sdsd  - Standard deviation of successive interval differences in ms.
+%     rmssd - Root mean square of successive interval differences in ms.
+%     pNN50 - Percentage of successive interval differences greater than 50 ms.
+%
+%   Example:
+%     dtk = [0.80 0.82 NaN 0.79 0.81];
+%     metrics = tdmetrics(dtk);
+%
+%   See also PANTOMPKINS
 
 narginchk(1, 1);
 nargoutchk(0, 1);

--- a/test/common/getBiosiglibRoot.m
+++ b/test/common/getBiosiglibRoot.m
@@ -22,18 +22,18 @@ if ~isfolder(biosiglibRoot)
         checkoutSource, biosiglibRoot);
 end
 
-requiredFiles = {
+requiredPaths = {
     fullfile('fixtures', 'catalog.json')
-    fullfile('conformance', 'hrv', 'tdmetrics', 'ecg_tk_001.json')
-    fullfile('conformance', 'ecg', 'pantompkins', 'edr_signals_001.json')
+    'conformance'
+    'specs'
     fullfile('schemas', 'implementation-manifest.schema.json')
 };
-for fileIndex = 1:numel(requiredFiles)
-    requiredPath = fullfile(biosiglibRoot, requiredFiles{fileIndex});
-    if ~isfile(requiredPath)
+for pathIndex = 1:numel(requiredPaths)
+    requiredPath = fullfile(biosiglibRoot, requiredPaths{pathIndex});
+    if ~(isfile(requiredPath) || isfolder(requiredPath))
         error('biosigmat:BiosiglibCheckoutIncomplete', ...
-            'Invalid Biosiglib checkout at %s: missing required file %s.', ...
-            biosiglibRoot, requiredFiles{fileIndex});
+            'Invalid Biosiglib checkout at %s: missing required path %s.', ...
+            biosiglibRoot, requiredPaths{pathIndex});
     end
 end
 

--- a/test/hrv/tdmetricsTest.m
+++ b/test/hrv/tdmetricsTest.m
@@ -3,12 +3,16 @@
 
 classdef tdmetricsTest < matlab.unittest.TestCase
     properties (TestParameter)
+        validCaseId = {
+            'hrv.tdmetrics.valid_dtk_001'
+            'hrv.tdmetrics.valid_dtk_with_nan_001'
+        }
         expectedErrorCaseId = {
-            'hrv.tdmetrics.invalid_tk_non_numeric'
-            'hrv.tdmetrics.invalid_tk_matrix'
-            'hrv.tdmetrics.invalid_tk_non_monotonic'
-            'hrv.tdmetrics.invalid_tk_repeated'
-            'hrv.tdmetrics.invalid_tk_negative'
+            'hrv.tdmetrics.invalid_dtk_non_numeric'
+            'hrv.tdmetrics.invalid_dtk_matrix'
+            'hrv.tdmetrics.invalid_dtk_negative'
+            'hrv.tdmetrics.invalid_dtk_zero'
+            'hrv.tdmetrics.invalid_dtk_inf'
         }
     end
 
@@ -24,11 +28,9 @@ classdef tdmetricsTest < matlab.unittest.TestCase
     end
 
     methods (Test)
-        function testBasicFunctionality(tc)
-            caseDefinition = loadBiosiglibConformanceCase( ...
-                'hrv.tdmetrics.ecg_tk_001');
-            tk = loadBiosiglibConformanceInput(caseDefinition, 'tk');
-            dtk = diff(tk);
+        function testBasicFunctionality(tc, validCaseId)
+            caseDefinition = loadBiosiglibConformanceCase(validCaseId);
+            dtk = loadBiosiglibConformanceInput(caseDefinition, 'dtk');
 
             metrics = tdmetrics(dtk);
 
@@ -38,29 +40,10 @@ classdef tdmetricsTest < matlab.unittest.TestCase
 
         function testExpectedError(tc, expectedErrorCaseId)
             caseDefinition = loadBiosiglibConformanceCase(expectedErrorCaseId);
-            tk = loadBiosiglibConformanceInput(caseDefinition, 'tk');
+            dtk = loadBiosiglibConformanceInput(caseDefinition, 'dtk');
 
             verifyBiosiglibExpectedError(tc, ...
-                @() tdmetricsFromCanonicalTk(tk), caseDefinition);
+                @() tdmetrics(dtk), caseDefinition);
         end
     end
-end
-
-function metrics = tdmetricsFromCanonicalTk(tk)
-%TDMETRICSFROMCANONICALTK Adapt canonical event times to interval input.
-
-if ~isnumeric(tk)
-    error('biosigmat:TdmetricsInvalidCanonicalType', ...
-        'Canonical tk input must be numeric.');
-end
-if ~isvector(tk)
-    error('biosigmat:TdmetricsInvalidCanonicalShape', ...
-        'Canonical tk input must be a vector.');
-end
-if any(~isfinite(tk)) || any(tk < 0) || any(diff(tk) <= 0)
-    error('biosigmat:TdmetricsInvalidCanonicalValue', ...
-        'Canonical tk input must be finite, non-negative, and strictly increasing.');
-end
-
-metrics = tdmetrics(diff(tk));
 end


### PR DESCRIPTION
## Summary

Adapts Biosigmat to Biosiglib v0.2.1 for the corrected `hrv.tdmetrics` contract.

## Changes

- Pins `conformance.json` to Biosiglib `v0.2.1` at `9322c84207eb1aeb6fedac6839bd1b1a71494bc2`.
- Updates `tdmetricsTest` from old `tk` cases to the current `dtk` cases.
- Removes hardcoded Biosiglib checkout validation for obsolete case files.
- Updates `tdmetrics` to validate canonical `dtk`, allow `NaN` markers, reject `Inf`/zero/negative intervals, and compute successive differences after omitting `NaN`.

## Notes

This fixes the propagation failure where Biosigmat still expected `conformance/hrv/tdmetrics/ecg_tk_001.json`, which no longer exists in Biosiglib v0.2.x.