### PR TITLE
[codex] Regenerate docs before Pages publishing

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,6 +36,28 @@ jobs:
             mkdocs-redirects \
             mkdocs-git-revision-date-localized-plugin
 
+      - name: Setup MATLAB
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: R2025a
+          cache: true
+          products: |
+            MATLAB
+            Signal_Processing_Toolbox
+            Curve_Fitting_Toolbox
+
+      - name: Regenerate docs from MATLAB headers
+        uses: matlab-actions/run-command@v2
+        with:
+          command: |
+            try
+              addpath('scripts/local');
+              updateDocs;
+            catch ME
+              fprintf('Documentation generation failed: %s\n', ME.message);
+              exit(1);
+            end
+
       - name: Build site
         run: mkdocs build --strict
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,18 @@
 - Resolve the Biosiglib checkout from `BIOSIGLIB_ROOT`, falling back to a sibling `../biosiglib` checkout.
 - Code, comments, filenames, and technical documentation must be in English.
 - Avoid generic resource APIs and unnecessary cross-language infrastructure.
+
+## Local change workflow
+
+- Work in a local checkout for multi-file changes.
+- Do not edit files one-by-one through the GitHub web/API connector except for tiny metadata-only changes.
+- Make related changes locally, run validation locally where possible, and push one coherent commit or a small coherent commit series.
+
+## Generated documentation
+
+- Documentation under `docs/api/` and generated `docs/examples/` is generated from MATLAB headers and example source files.
+- Do not manually edit generated documentation files.
+- Edit the relevant MATLAB function headers and example `.m` files instead.
+- Regenerate documentation with `scripts/local/updateDocs.m`.
+- If generated docs change in a PR, the PR description must state that `updateDocs` was run.
+- If `updateDocs` cannot be run, do not hand-edit generated docs as a substitute; document the blocker.


### PR DESCRIPTION
## Summary

- Expanded `AGENTS.md` guidance so agents and contributors use local checkouts for multi-file changes, avoid one-file-at-a-time GitHub connector edits except tiny metadata-only changes, validate locally, and push coherent commits.
- Added generated documentation guidance explaining that `docs/api/` and generated `docs/examples/` come from MATLAB headers and example source files, should not be hand-edited, and should be regenerated with `scripts/local/updateDocs.m`.
- Updated the Pages docs workflow to set up MATLAB R2025a with the same products used by MATLAB CI, then run `updateDocs` before `mkdocs build --strict`.
- Pages now builds from docs regenerated by `updateDocs` in the Actions workspace before publishing.

## Validation

- `git diff --check`: passed. Git printed local LF-to-CRLF working-copy warnings for the two edited files.
- `matlab -batch "addpath('scripts/local'); updateDocs"`: passed; documentation update completed successfully.
- `.github/workflows/docs.yaml` YAML parse check with a temporary PyYAML install: passed (`docs.yaml parsed successfully`).

## Notes

- No stale-docs `git diff --exit-code` check was added.
- The workflow does not commit generated docs back to `main`.
- If `updateDocs` fails in the Pages workflow, the workflow exits non-zero before MkDocs build and Pages deployment.