### PR TITLE
docs: simplify README conformance section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,9 @@
 - Resolve the Biosiglib checkout from `BIOSIGLIB_ROOT`, falling back to a sibling `../biosiglib` checkout.
 - Code, comments, filenames, and technical documentation must be in English.
 - Avoid generic resource APIs and unnecessary cross-language infrastructure.
+- Do not change scientific or computational behavior without explicit maintainer review. This includes filtering direction and phase behavior, NaN handling, default filters, default parameters, units, physiological interpretation, and reference-result provenance.
+- Treat Biosigmat as the mature starting implementation, not as automatically correct. If Biosigmat and Biosigpy disagree in a scientifically meaningful way, document the disagreement and ask the maintainer before changing either implementation or the Biosiglib specification.
+- Do not ask about purely idiomatic differences unless they affect scientific behavior. Examples: zero-based versus one-based internal indexing, exception class names, plotting library choices, or local variable names normally do not require maintainer escalation.
 
 ## Local change workflow
 

--- a/README.md
+++ b/README.md
@@ -25,39 +25,21 @@ addpath(genpath('path/to/biosigmat'));
 
 ## Biosiglib conformance
 
-Biosigmat is the MATLAB implementation of the language-independent [Biosiglib](https://github.com/BSICoS/biosiglib) specifications. The root `conformance.json` pins the exact Biosiglib revision used by shared conformance tests. Tests resolve Biosiglib from `BIOSIGLIB_ROOT` when it is set and otherwise use a sibling `../biosiglib` checkout.
+Biosigmat is the MATLAB implementation of the language-independent [Biosiglib](https://github.com/BSICoS/biosiglib) specifications. The root `conformance.json` pins the exact Biosiglib revision used by shared conformance tests.
 
-Run the complete MATLAB suite from the Biosigmat repository root with the existing runner:
+See [Conformance](docs/conformance.md) for validation commands and local checkout details.
 
-```powershell
-matlab -batch "addpath('scripts/local'); runTests"
-```
-
-Validate the manifest with the pinned Biosiglib checkout and its repository-local virtual environment:
-
-```powershell
-$biosiglibRoot = if ($env:BIOSIGLIB_ROOT) { $env:BIOSIGLIB_ROOT } else { (Resolve-Path ..\biosiglib).Path }
-& "$biosiglibRoot\.venv\Scripts\python.exe" "$biosiglibRoot\tools\validate_specs.py" --manifest "$PWD\conformance.json"
-```
-
-## 📚 Documentation
+## Documentation
 
 > **Documentation site**  
-> 🌐 **Visit**: [https://bsicos.github.io/biosigmat/](https://bsicos.github.io/biosigmat/)
+> Visit: [https://bsicos.github.io/biosigmat/](https://bsicos.github.io/biosigmat/)
 
-Our documentation includes:
-
-- 🚀 **Getting Started Guide** - Quick setup and first steps
-- 📖 **Complete API Reference** - Detailed function documentation
-- 💡 **Examples & Tutorials** - Practical use cases with code
-- 🔧 **Contributing Guidelines** - How to contribute to the project
-- 📋 **Code Style Guide** - Standards and best practices
+The documentation includes getting-started material, API reference pages, examples, contribution guidance, and code-style notes.
 
 ## Support
 
-- 🐛 Report issues on [GitHub Issues](https://github.com/BSICoS/biosigmat/issues)
-- 📧 Contact the development team for additional support
-
+- Report issues on [GitHub Issues](https://github.com/BSICoS/biosigmat/issues)
+- Contact the development team for additional support
 
 ## License
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,29 @@
+# Conformance
+
+Biosigmat is the MATLAB implementation of the language-independent [Biosiglib](https://github.com/BSICoS/biosiglib) specifications.
+
+The root `conformance.json` pins the exact Biosiglib revision used by shared conformance tests. Tests resolve Biosiglib from `BIOSIGLIB_ROOT` when it is set and otherwise use a sibling `../biosiglib` checkout.
+
+## Run the MATLAB test suite
+
+Run the complete MATLAB suite from the Biosigmat repository root with the existing runner:
+
+```powershell
+matlab -batch "addpath('scripts/local'); runTests"
+```
+
+## Validate the conformance manifest
+
+Validate the manifest with the pinned Biosiglib checkout and its repository-local virtual environment:
+
+```powershell
+$biosiglibRoot = if ($env:BIOSIGLIB_ROOT) { $env:BIOSIGLIB_ROOT } else { (Resolve-Path ..\biosiglib).Path }
+& "$biosiglibRoot\.venv\Scripts\python.exe" "$biosiglibRoot\tools\validate_specs.py" --manifest "$PWD\conformance.json"
+```
+
+On Linux or macOS, use the equivalent Python executable from the Biosiglib `.venv`:
+
+```bash
+biosiglib_root="${BIOSIGLIB_ROOT:-../biosiglib}"
+"$biosiglib_root/.venv/bin/python" "$biosiglib_root/tools/validate_specs.py" --manifest "$PWD/conformance.json"
+```


### PR DESCRIPTION
## Summary

- Keeps the README short and points detailed conformance commands to `docs/conformance.md`.
- Adds a standalone conformance guide with MATLAB test and manifest-validation commands.
- Clarifies in `AGENTS.md` that scientific/computational behavior changes require maintainer review.

## Notes

No generated `docs/api/` or `docs/examples/` files were edited.

## Validation

Not run locally from this connector session.