### PR TITLE
Align tools with Biosiglib v0.5.5 specs

### DIFF
--- a/conformance.json
+++ b/conformance.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/BSICoS/biosiglib/10dcedf74d665eb0914bcde9b81eaa77c986bf76/schemas/implementation-manifest.schema.json",
+  "$schema": "https://raw.githubusercontent.com/BSICoS/biosiglib/867e5aa8d73c7c96260a5769f6a5b667d7e65a57/schemas/implementation-manifest.schema.json",
   "implementation": {
     "name": "biosigmat",
     "language": "MATLAB",
@@ -7,8 +7,8 @@
   },
   "biosiglib": {
     "repository": "https://github.com/BSICoS/biosiglib",
-    "commit": "10dcedf74d665eb0914bcde9b81eaa77c986bf76",
-    "release": "0.5.0"
+    "commit": "867e5aa8d73c7c96260a5769f6a5b667d7e65a57",
+    "release": "0.5.2"
   },
   "specifications": {
     "hrv.tdmetrics": {

--- a/conformance.json
+++ b/conformance.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/BSICoS/biosiglib/fb526f61c484fdb38e7df936a07d3a0563d94d42/schemas/implementation-manifest.schema.json",
+  "$schema": "https://raw.githubusercontent.com/BSICoS/biosiglib/9844bd742d6c375f472dceb16adaae97e700509b/schemas/implementation-manifest.schema.json",
   "implementation": {
     "name": "biosigmat",
     "language": "MATLAB",
@@ -7,8 +7,8 @@
   },
   "biosiglib": {
     "repository": "https://github.com/BSICoS/biosiglib",
-    "commit": "fb526f61c484fdb38e7df936a07d3a0563d94d42",
-    "release": "0.5.4"
+    "commit": "9844bd742d6c375f472dceb16adaae97e700509b",
+    "release": "0.5.5"
   },
   "specifications": {
     "hrv.tdmetrics": {
@@ -22,6 +22,26 @@
     "ecg.sloperange": {
       "status": "conformant",
       "entry_point": "sloperange"
+    },
+    "tools.medfilt_threshold": {
+      "status": "conformant",
+      "entry_point": "medfiltThreshold"
+    },
+    "tools.nan_filter": {
+      "status": "conformant",
+      "entry_point": "nanfilter"
+    },
+    "tools.nan_filtfilt": {
+      "status": "conformant",
+      "entry_point": "nanfiltfilt"
+    },
+    "tools.lpd_filter": {
+      "status": "conformant",
+      "entry_point": "lpdfilter"
+    },
+    "tools.snap_to_peak": {
+      "status": "conformant",
+      "entry_point": "snaptopeak"
     }
   }
 }

--- a/conformance.json
+++ b/conformance.json
@@ -8,7 +8,7 @@
   "biosiglib": {
     "repository": "https://github.com/BSICoS/biosiglib",
     "commit": "867e5aa8d73c7c96260a5769f6a5b667d7e65a57",
-    "release": "0.5.2"
+    "release": "0.5.3"
   },
   "specifications": {
     "hrv.tdmetrics": {

--- a/src/ecg/pantompkins.m
+++ b/src/ecg/pantompkins.m
@@ -78,6 +78,7 @@ locs = unique(locs);
 % Refine peak locations using snaptopeak if enabled
 if ~isempty(locs)
     locs = snaptopeak(ecg, locs, 'WindowSize', snapTopeakWindowSize);
+    locs = locs(~isnan(locs));
 end
 
 % Convert peak locations to ECG R-wave occurrence times in seconds

--- a/src/tools/medfiltThreshold.m
+++ b/src/tools/medfiltThreshold.m
@@ -28,10 +28,10 @@ nargoutchk(0, 1);
 % Parse and validate inputs
 parser = inputParser;
 parser.FunctionName = 'medfiltThreshold';
-addRequired(parser, 'x', @(x) isnumeric(x) && isvector(x) && ~isempty(x));
-addRequired(parser, 'window', @(x) isnumeric(x) && isscalar(x) && x > 0 && x == round(x));
-addRequired(parser, 'factor', @(x) isnumeric(x) && isscalar(x) && x > 0);
-addRequired(parser, 'maxthreshold', @(x) isnumeric(x) && isscalar(x) && x > 0);
+addRequired(parser, 'x', @(x) isnumeric(x) && isvector(x) && numel(x) >= 2 && all(~isinf(x(:))));
+addRequired(parser, 'window', @(x) isnumeric(x) && isscalar(x) && isfinite(x) && x >= 2 && x == round(x));
+addRequired(parser, 'factor', @(x) isnumeric(x) && isscalar(x) && isfinite(x) && x > 0);
+addRequired(parser, 'maxthreshold', @(x) isnumeric(x) && isscalar(x) && isfinite(x) && x > 0);
 
 parse(parser, x, window, factor, maxthreshold);
 

--- a/src/tools/nanfilter.m
+++ b/src/tools/nanfilter.m
@@ -8,13 +8,13 @@ function y = nanfilter(b, a, x, maxgap)
 %   Y = NANFILTER(B, A, X, MAXGAP) allows specifying a maximum gap size MAXGAP.
 %
 %   Algorithm:
-%     1. For each column, identify NaN sequences and classify them as long (> MAXGAP)
-%        or short (<= MAXGAP).
-%     2. If no long NaN sequences exist, process the entire column with interpolation.
-%     3. If long NaN sequences exist, divide the column into valid segments.
-%     4. Process each valid segment independently using filter after interpolating
-%        any short NaN gaps within the segment.
-%     5. Restore the original long NaN gaps in the final result.
+%     1. For each column, classify NaN sequences as boundary gaps, internal
+%        short gaps (<= MAXGAP), or preserved internal long gaps (> MAXGAP).
+%     2. Preserve boundary and long internal gaps as NaN and use them to
+%        split the signal into candidate finite segments.
+%     3. Interpolate short internal gaps within each candidate segment.
+%     4. Process filterable segments independently using filter.
+%     5. Leave segments shorter than max(length(B), length(A)) as NaN.
 %
 %   Example:
 %     % Filter a noisy signal with NaN gaps
@@ -42,6 +42,7 @@ else
 end
 
 % Use common NaN filtering logic
-y = processNanSignal(b, a, x, maxgap, @filter);
+minimumSegmentLength = max(length(a), length(b));
+y = processNanSignal(b, a, x, maxgap, @filter, minimumSegmentLength);
 
 end

--- a/src/tools/nanfiltfilt.m
+++ b/src/tools/nanfiltfilt.m
@@ -16,13 +16,13 @@ function y = nanfiltfilt(b, a, x, maxgap)
 %   Y = NANFILTFILT(B, A, X, MAXGAP) allows specifying a maximum gap size MAXGAP.
 %
 %   Algorithm:
-%     1. For each column, identify NaN sequences and classify them as long (> MAXGAP)
-%        or short (<= MAXGAP).
-%     2. If no long NaN sequences exist, process the entire column with interpolation.
-%     3. If long NaN sequences exist, divide the column into valid segments.
-%     4. Process each valid segment independently using filter after interpolating
-%        any short NaN gaps within the segment.
-%     5. Restore the original long NaN gaps in the final result.
+%     1. For each column, classify NaN sequences as boundary gaps, internal
+%        short gaps (<= MAXGAP), or preserved internal long gaps (> MAXGAP).
+%     2. Preserve boundary and long internal gaps as NaN and use them to
+%        split the signal into candidate finite segments.
+%     3. Interpolate short internal gaps within each candidate segment.
+%     4. Process filterable segments independently using filtfilt.
+%     5. Leave segments too short for MATLAB-style filtfilt as NaN.
 %
 %   NANFILTFILT should not be used when the intent of a filter is to modify
 %   signal phase, as is the case with differentiators and Hilbert filters.
@@ -53,6 +53,8 @@ else
 end
 
 % Use common NaN filtering logic
-y = processNanSignal(b, a, x, maxgap, @filtfilt);
+filterOrder = max(length(b) - 1, length(a) - 1);
+minimumSegmentLength = 3 * filterOrder + 1;
+y = processNanSignal(b, a, x, maxgap, @filtfilt, minimumSegmentLength);
 
 end

--- a/src/tools/private/processNanSignal.m
+++ b/src/tools/private/processNanSignal.m
@@ -1,8 +1,8 @@
-function y = processNanSignal(b, a, x, maxgap, filterFunc)
+function y = processNanSignal(b, a, x, maxgap, filterFunc, minimumSegmentLength)
 % PROCESSNANSIGNAL Common function for processing signals with NaN values
 %
 % This function implements the common logic for both nanFilter and nanFiltFilt
-% by processing signals in segments separated by long NaN gaps.
+% by processing signals in segments separated by preserved NaN gaps.
 %
 % Inputs:
 %   b          - Numerator coefficients of the filter
@@ -10,12 +10,13 @@ function y = processNanSignal(b, a, x, maxgap, filterFunc)
 %   x          - Input matrix with signals in columns that can include NaN values
 %   maxgap     - Maximum gap size to interpolate
 %   filterFunc - Function handle (@filter or @filtfilt)
+%   minimumSegmentLength - Minimum samples required to filter a segment
 %
 % Outputs:
 %   y          - Matrix of processed signals in columns with NaN values preserved
 
 % Check number of input and output arguments
-narginchk(5, 5);
+narginchk(6, 6);
 nargoutchk(0, 1);
 
 % Parse and validate inputs
@@ -26,24 +27,24 @@ addRequired(parser, 'a', @(v) isnumeric(v) && isvector(v));
 addRequired(parser, 'x', @(v) ismatrix(v));
 addRequired(parser, 'maxgap', @(v) isnumeric(v) && isscalar(v) && v >= 0);
 addRequired(parser, 'filterFunc', @(v) isa(v, 'function_handle'));
-parse(parser, b, a, x, maxgap, filterFunc);
+addRequired(parser, 'minimumSegmentLength', @(v) isnumeric(v) && isscalar(v) && v >= 1);
+parse(parser, b, a, x, maxgap, filterFunc, minimumSegmentLength);
 
 b = parser.Results.b;
 a = parser.Results.a;
 x = parser.Results.x;
 maxgap = parser.Results.maxgap;
 filterFunc = parser.Results.filterFunc;
-
-% Find NaNs
-idxNan = isnan(x);
+minimumSegmentLength = parser.Results.minimumSegmentLength;
 
 % Handle row vectors by transposing
 wasRowVector = false;
 if isrow(x)
     wasRowVector = true;
     x = x';
-    idxNan = idxNan';
 end
+
+idxNan = isnan(x);
 
 if all(idxNan(:))
     y = x;
@@ -72,57 +73,61 @@ for col = 1:size(x,2)
         seqs = seqs(seqs(:,1) == 1, :);
     end
 
-    % Separate long NaN segments (> maxgap) from short ones (<= maxgap)
-    if ~isempty(seqs)
-        longNanSeqs = seqs(seqs(:,4) > maxgap, :);
-    else
-        longNanSeqs = [];
+    % findsequences detects repeated runs, so add isolated NaN samples as
+    % one-sample sequences before classifying gaps.
+    if any(idxNanCol)
+        coveredNan = false(size(idxNanCol));
+        for s = 1:size(seqs, 1)
+            coveredNan(seqs(s, 2):seqs(s, 3)) = true;
+        end
+
+        isolatedNanIndices = find(idxNanCol & ~coveredNan);
+        if ~isempty(isolatedNanIndices)
+            isolatedNanSeqs = [ ...
+                ones(numel(isolatedNanIndices), 1), ...
+                isolatedNanIndices, ...
+                isolatedNanIndices, ...
+                ones(numel(isolatedNanIndices), 1)];
+            seqs = [seqs; isolatedNanSeqs]; %#ok<AGROW>
+        end
+
+        seqs = sortrows(seqs, 2);
     end
 
-    if isempty(longNanSeqs)
-        % No long NaN segments, process entire column with interpolation
-        colFilled = fillmissing(colData, 'linear');
-        colFiltered = filterFunc(b, a, colFilled);
-        y(:,col) = colFiltered;
-
-        % Keep short NaN segments interpolated (do not restore them)
-        % Only restore NaN segments that are longer than maxgap
-        % Since longNanSeqs is empty, there are no long segments to restore
+    % Boundary NaN gaps and long internal NaN gaps are preserved as NaN.
+    % Short internal gaps are interpolated within their candidate segment.
+    if isempty(seqs)
+        preservedNanSeqs = [];
     else
-        % Process valid segments between long NaN gaps separately
-        validSegments = getValidSegments(colData, longNanSeqs);
+        isBoundaryGap = seqs(:,2) == 1 | seqs(:,3) == length(colData);
+        isLongInternalGap = ~isBoundaryGap & seqs(:,4) > maxgap;
+        preservedNanSeqs = seqs(isBoundaryGap | isLongInternalGap, :);
+    end
 
-        for segIdx = 1:size(validSegments,1)
-            startIdx = validSegments(segIdx,1);
-            endIdx = validSegments(segIdx,2);
+    % Process valid segments between preserved NaN gaps separately
+    validSegments = getValidSegments(colData, preservedNanSeqs);
 
-            if startIdx > endIdx
-                continue; % Skip invalid segments
-            end
+    for segIdx = 1:size(validSegments,1)
+        startIdx = validSegments(segIdx,1);
+        endIdx = validSegments(segIdx,2);
 
-            segmentData = colData(startIdx:endIdx);
-
-            % Fill short NaN gaps within this segment
-            segmentFilled = fillmissing(segmentData, 'linear');
-
-            % Apply filter to this segment
-            if length(segmentFilled) >= max(length(a), length(b))
-                segmentFiltered = filterFunc(b, a, segmentFilled);
-                y(startIdx:endIdx,col) = segmentFiltered;
-
-                % Do not restore short NaN segments within this segment
-                % They should remain interpolated since they are <= maxgap
-                % Only long NaN segments are restored later
-            else
-                % Segment too short for filtering, keep original with interpolation
-                y(startIdx:endIdx,col) = segmentFilled;
-            end
+        if startIdx > endIdx
+            continue; % Skip invalid segments
         end
 
-        % Restore long NaN segments
-        for s = 1:size(longNanSeqs,1)
-            y(longNanSeqs(s,2):longNanSeqs(s,3),col) = NaN;
+        segmentData = colData(startIdx:endIdx);
+
+        % Fill short NaN gaps within this segment. Boundary and long gaps
+        % have already split the segment, so no extrapolation is allowed.
+        segmentFilled = fillmissing(segmentData, 'linear', 'EndValues', 'none');
+
+        % Apply the selected filter only to segments that meet its minimum
+        % length; too-short candidate segments remain NaN in the output.
+        if any(isnan(segmentFilled)) || length(segmentFilled) < minimumSegmentLength
+            continue;
         end
+
+        y(startIdx:endIdx,col) = filterFunc(b, a, segmentFilled);
     end
 end
 

--- a/src/tools/snaptopeak.m
+++ b/src/tools/snaptopeak.m
@@ -8,8 +8,8 @@ function refinedDetections = snaptopeak(ecg, detections, varargin)
 %   positions in samples. This improves the precision of R-wave peak
 %   localization by ensuring detections align with actual signal peaks.
 %   Returns REFINEDDETECTIONS as a column vector of refined positions with
-%   the same length as DETECTIONS. ECG and DETECTIONS must contain finite
-%   numeric values.
+%   the same length as DETECTIONS. NaN values in ECG act as hard segment
+%   boundaries, and NaN detections produce NaN outputs at the same positions.
 %
 %   REFINEDDETECTIONS = SNAPTOPEAK(..., 'WindowSize', WINDOWSIZE)
 %   specifies the search window size WINDOWSIZE in samples around each
@@ -43,9 +43,9 @@ nargoutchk(0, 1);
 % Parse input arguments
 parser = inputParser;
 parser.FunctionName = 'snaptopeak';
-addRequired(parser, 'ecg', @(x) isnumeric(x) && ~ischar(x) && isvector(x) && numel(x) >= 2 && all(isfinite(x(:))));
-addRequired(parser, 'detections', @(x) isnumeric(x) && ~ischar(x) && (isempty(x) || isvector(x)) && all(isfinite(x(:))));
-addParameter(parser, 'WindowSize', 20, @(x) isnumeric(x) && isscalar(x) && x > 0);
+addRequired(parser, 'ecg', @(x) isnumeric(x) && ~ischar(x) && isvector(x) && numel(x) >= 2 && all(~isinf(x(:))));
+addRequired(parser, 'detections', @(x) isnumeric(x) && ~ischar(x) && (isempty(x) || isvector(x)) && all(~isinf(x(:))));
+addParameter(parser, 'WindowSize', 20, @(x) isnumeric(x) && isscalar(x) && isfinite(x) && x > 0);
 
 parse(parser, ecg, detections, varargin{:});
 
@@ -63,21 +63,49 @@ end
 ecg = ecg(:);
 detections = detections(:);
 
-% Validate detection positions are within ECG signal bounds
-if any(detections < 1) || any(detections > length(ecg))
+finiteDetections = detections(~isnan(detections));
+
+% Validate finite detection positions are within ECG signal bounds
+if any(finiteDetections < 1) || any(finiteDetections > length(ecg))
     error('Detection positions must be within ECG signal bounds (1 to %d)', length(ecg));
 end
 
 % Initialize output
-refinedDetections = zeros(size(detections));
+refinedDetections = NaN(size(detections));
+
+finiteEcg = isfinite(ecg);
+finiteTransitions = diff([false; finiteEcg; false]);
+finiteSegmentStarts = find(finiteTransitions == 1);
+finiteSegmentEnds = find(finiteTransitions == -1) - 1;
 
 % Process each detection
 for i = 1:length(detections)
     currentDetection = detections(i);
 
-    % Define search window boundaries
-    windowStart = max(1, currentDetection - windowSize);
-    windowEnd = min(length(ecg), currentDetection + windowSize);
+    if isnan(currentDetection)
+        continue;
+    end
+
+    detectionSample = round(currentDetection);
+    if isnan(ecg(detectionSample))
+        continue;
+    end
+
+    segmentIndex = find( ...
+        finiteSegmentStarts <= detectionSample & ...
+        finiteSegmentEnds >= detectionSample, 1);
+
+    % This should only happen for invalid finite values, already rejected.
+    if isempty(segmentIndex)
+        continue;
+    end
+
+    segmentStart = finiteSegmentStarts(segmentIndex);
+    segmentEnd = finiteSegmentEnds(segmentIndex);
+
+    % Define search window boundaries without crossing NaN gaps
+    windowStart = max([1, segmentStart, detectionSample - windowSize]);
+    windowEnd = min([length(ecg), segmentEnd, detectionSample + windowSize]);
 
     % Extract signal window
     windowSignal = ecg(windowStart:windowEnd);

--- a/src/tools/snaptopeak.m
+++ b/src/tools/snaptopeak.m
@@ -8,7 +8,8 @@ function refinedDetections = snaptopeak(ecg, detections, varargin)
 %   positions in samples. This improves the precision of R-wave peak
 %   localization by ensuring detections align with actual signal peaks.
 %   Returns REFINEDDETECTIONS as a column vector of refined positions with
-%   the same length as DETECTIONS.
+%   the same length as DETECTIONS. ECG and DETECTIONS must contain finite
+%   numeric values.
 %
 %   REFINEDDETECTIONS = SNAPTOPEAK(..., 'WindowSize', WINDOWSIZE)
 %   specifies the search window size WINDOWSIZE in samples around each
@@ -42,8 +43,8 @@ nargoutchk(0, 1);
 % Parse input arguments
 parser = inputParser;
 parser.FunctionName = 'snaptopeak';
-addRequired(parser, 'ecg', @(x) isnumeric(x) && ~ischar(x) && isvector(x) && ~isscalar(x) && ~isempty(x));
-addRequired(parser, 'detections', @(x) isnumeric(x) && ~ischar(x));
+addRequired(parser, 'ecg', @(x) isnumeric(x) && ~ischar(x) && isvector(x) && numel(x) >= 2 && all(isfinite(x(:))));
+addRequired(parser, 'detections', @(x) isnumeric(x) && ~ischar(x) && (isempty(x) || isvector(x)) && all(isfinite(x(:))));
 addParameter(parser, 'WindowSize', 20, @(x) isnumeric(x) && isscalar(x) && x > 0);
 
 parse(parser, ecg, detections, varargin{:});

--- a/test/common/NanFilterTestBase.m
+++ b/test/common/NanFilterTestBase.m
@@ -11,8 +11,13 @@ classdef NanFilterTestBase < matlab.unittest.TestCase
     end
 
     methods (TestClassSetup)
-        function addCodeToPath(~)
-            addpath('../../src/tools');
+        function addCodeToPath(tc)
+            testDirectory = fileparts(mfilename('fullpath'));
+            repositoryRoot = fileparts(fileparts(testDirectory));
+            originalPath = path;
+            tc.addTeardown(@() path(originalPath));
+            addpath(fullfile(repositoryRoot, 'src', 'tools'));
+            addpath(fullfile(repositoryRoot, 'test', 'common'));
         end
     end
 
@@ -117,6 +122,26 @@ classdef NanFilterTestBase < matlab.unittest.TestCase
             expectedMat = standardFunc(tc.b, tc.a, signalMat);
 
             tc.verifyEqual(filteredMat, expectedMat, 'Multi-column filtering failed', 'AbsTol', 1e-6);
+        end
+
+        function verifyBiosiglibNanFilteringCase(tc, filterFunc, caseId)
+            caseDefinition = loadBiosiglibConformanceCase(caseId);
+            b = loadBiosiglibConformanceInput( ...
+                caseDefinition, 'numerator_coefficients');
+            a = loadBiosiglibConformanceInput( ...
+                caseDefinition, 'denominator_coefficients');
+            signal = loadBiosiglibConformanceInput(caseDefinition, 'signal');
+
+            if isfield(caseDefinition, 'parameters') && ...
+                    isfield(caseDefinition.parameters, 'max_gap')
+                filteredSignal = filterFunc( ...
+                    b, a, signal, caseDefinition.parameters.max_gap);
+            else
+                filteredSignal = filterFunc(b, a, signal);
+            end
+
+            actualOutputs = struct('filtered_signal', filteredSignal);
+            verifyBiosiglibExpectedOutputs(tc, actualOutputs, caseDefinition);
         end
     end
 

--- a/test/common/verifyBiosiglibExpectedOutputs.m
+++ b/test/common/verifyBiosiglibExpectedOutputs.m
@@ -5,8 +5,13 @@ if nargin < 4
     outputIdMap = containers.Map('KeyType', 'char', 'ValueType', 'char');
 end
 
-for outputIndex = 1:numel(caseDefinition.expected_outputs)
-    expectedOutput = caseDefinition.expected_outputs(outputIndex);
+expectedOutputs = caseDefinition.expected_outputs;
+for outputIndex = 1:numel(expectedOutputs)
+    if iscell(expectedOutputs)
+        expectedOutput = expectedOutputs{outputIndex};
+    else
+        expectedOutput = expectedOutputs(outputIndex);
+    end
     outputId = expectedOutput.id;
 
     if isKey(outputIdMap, outputId)

--- a/test/tools/lpdfilterTest.m
+++ b/test/tools/lpdfilterTest.m
@@ -13,13 +13,29 @@ classdef lpdfilterTest < matlab.unittest.TestCase
         t;
     end
 
+    properties (TestParameter)
+        validConformanceCaseId = {
+            'tools.lpd_filter.fs256_stop12_order4_coefficients'
+            'tools.lpd_filter.explicit_pass_frequency_order4_coefficients'
+        }
+        expectedErrorCaseId = {
+            'tools.lpd_filter.invalid_pass_frequency_not_less_than_stop'
+            'tools.lpd_filter.invalid_stop_frequency_at_nyquist'
+        }
+    end
+
     methods (TestClassSetup)
         function addPathsAndData(tc)
-            % Add required paths
-            addpath(fullfile(pwd, '..', '..', 'src', 'tools'));
+            testDirectory = fileparts(mfilename('fullpath'));
+            repositoryRoot = fileparts(fileparts(testDirectory));
+            originalPath = path;
+            tc.addTeardown(@() path(originalPath));
+            addpath(fullfile(repositoryRoot, 'src', 'tools'));
+            addpath(fullfile(repositoryRoot, 'test', 'common'));
 
             % Load real PPG data from fixtures
-            data = readtable(fullfile(pwd, '..', '..', 'fixtures', 'ppg', 'ppg_signals.csv'));
+            data = readtable(fullfile( ...
+                repositoryRoot, 'fixtures', 'ppg', 'ppg_signals.csv'));
 
             % Use 30 seconds of data
             duration = 30;
@@ -31,7 +47,43 @@ classdef lpdfilterTest < matlab.unittest.TestCase
         end
     end
 
+    methods (Access = private)
+        function [b, delay] = callLpdFilterFromCase(~, caseDefinition)
+            samplingFrequency = loadBiosiglibConformanceInput( ...
+                caseDefinition, 'sampling_frequency');
+            stopFrequency = loadBiosiglibConformanceInput( ...
+                caseDefinition, 'stop_frequency');
+            parameters = caseDefinition.parameters;
+            optionalArgs = {};
+
+            if isfield(parameters, 'pass_frequency')
+                optionalArgs = [optionalArgs, {'PassFreq', parameters.pass_frequency}]; %#ok<AGROW>
+            end
+            if isfield(parameters, 'order')
+                optionalArgs = [optionalArgs, {'Order', parameters.order}]; %#ok<AGROW>
+            end
+
+            [b, delay] = lpdfilter(samplingFrequency, stopFrequency, optionalArgs{:});
+        end
+    end
+
     methods (Test)
+        function testBiosiglibConformanceCase(tc, validConformanceCaseId)
+            caseDefinition = loadBiosiglibConformanceCase(validConformanceCaseId);
+
+            [b, delay] = tc.callLpdFilterFromCase(caseDefinition);
+
+            actualOutputs = struct('filter_coefficients', b, 'delay', delay);
+            verifyBiosiglibExpectedOutputs(tc, actualOutputs, caseDefinition);
+        end
+
+        function testBiosiglibExpectedError(tc, expectedErrorCaseId)
+            caseDefinition = loadBiosiglibConformanceCase(expectedErrorCaseId);
+
+            verifyBiosiglibExpectedError(tc, ...
+                @() tc.callLpdFilterFromCase(caseDefinition), caseDefinition);
+        end
+
         function testBasicFunctionality(tc)
             stopFreq = 8.0;
             [b, delay] = lpdfilter(tc.fs, stopFreq);

--- a/test/tools/medfiltThresholdTest.m
+++ b/test/tools/medfiltThresholdTest.m
@@ -9,21 +9,68 @@ classdef medfiltThresholdTest < matlab.unittest.TestCase
         dtk
     end
 
+    properties (TestParameter)
+        validConformanceCaseId = {
+            'tools.medfilt_threshold.normal_outlier'
+            'tools.medfilt_threshold.window_larger_than_signal'
+            'tools.medfilt_threshold.even_window_behavior'
+            'tools.medfilt_threshold.odd_window_behavior'
+            'tools.medfilt_threshold.row_vector_orientation'
+            'tools.medfilt_threshold.max_threshold_cap'
+            'tools.medfilt_threshold.include_nan_window'
+        }
+        expectedErrorCaseId = {
+            'tools.medfilt_threshold.invalid_window_one'
+            'tools.medfilt_threshold.invalid_single_sample'
+        }
+    end
+
     methods (TestClassSetup)
-        function addCodeToPath(~)
-            addpath('../../src/tools');
+        function addCodeToPath(tc)
+            testDirectory = fileparts(mfilename('fullpath'));
+            repositoryRoot = fileparts(fileparts(testDirectory));
+            originalPath = path;
+            tc.addTeardown(@() path(originalPath));
+            addpath(fullfile(repositoryRoot, 'src', 'tools'));
+            addpath(fullfile(repositoryRoot, 'test', 'common'));
         end
     end
 
     methods (TestMethodSetup)
         function loadFixtures(tc)
-            tkData = readtable('../../fixtures/ecg/medicom_mtd_r_wave_timing.csv');
+            testDirectory = fileparts(mfilename('fullpath'));
+            repositoryRoot = fileparts(fileparts(testDirectory));
+            tkData = readtable(fullfile( ...
+                repositoryRoot, 'fixtures', 'ecg', 'medicom_mtd_r_wave_timing.csv'));
             tc.tk = tkData.r_wave_times;
             tc.dtk = diff(tc.tk);
         end
     end
 
     methods (Test)
+        function testBiosiglibConformanceCase(tc, validConformanceCaseId)
+            caseDefinition = loadBiosiglibConformanceCase(validConformanceCaseId);
+            x = loadBiosiglibConformanceInput(caseDefinition, 'x');
+            parameters = caseDefinition.parameters;
+
+            threshold = medfiltThreshold( ...
+                x, parameters.window, parameters.factor, parameters.max_threshold);
+
+            actualOutputs = struct('threshold', threshold);
+            verifyBiosiglibExpectedOutputs(tc, actualOutputs, caseDefinition);
+        end
+
+        function testBiosiglibExpectedError(tc, expectedErrorCaseId)
+            caseDefinition = loadBiosiglibConformanceCase(expectedErrorCaseId);
+            x = loadBiosiglibConformanceInput(caseDefinition, 'x');
+            parameters = caseDefinition.parameters;
+
+            verifyBiosiglibExpectedError(tc, ...
+                @() medfiltThreshold( ...
+                    x, parameters.window, parameters.factor, parameters.max_threshold), ...
+                caseDefinition);
+        end
+
         function testBasicFuntionality(tc)
             % Create modified tk with 4 gaps
             tkWithGaps = tc.tk;

--- a/test/tools/nanfilterTest.m
+++ b/test/tools/nanfilterTest.m
@@ -9,7 +9,23 @@
 
 classdef nanfilterTest < NanFilterTestBase
 
+    properties (TestParameter)
+        validConformanceCaseId = {
+            'tools.nan_filter.no_nan_equivalent_filter'
+            'tools.nan_filter.short_nan_gap_interpolation'
+            'tools.nan_filter.long_nan_gap_segmentation'
+            'tools.nan_filter.row_vector_orientation'
+            'tools.nan_filter.boundary_nan_preserved'
+            'tools.nan_filter.too_short_segments_nan'
+        }
+    end
+
     methods (Test)
+        function testBiosiglibConformanceCase(tc, validConformanceCaseId)
+            tc.verifyBiosiglibNanFilteringCase( ...
+                @nanfilter, validConformanceCaseId);
+        end
+
         function testNoNanSignal(tc)
             tc.verifyNoNaNSignal(@nanfilter, @filter);
         end

--- a/test/tools/nanfiltfiltTest.m
+++ b/test/tools/nanfiltfiltTest.m
@@ -9,7 +9,23 @@
 
 classdef nanfiltfiltTest < NanFilterTestBase
 
+    properties (TestParameter)
+        validConformanceCaseId = {
+            'tools.nan_filtfilt.no_nan_equivalent_filtfilt'
+            'tools.nan_filtfilt.short_nan_gap_interpolation'
+            'tools.nan_filtfilt.long_nan_gap_segmentation'
+            'tools.nan_filtfilt.row_vector_orientation'
+            'tools.nan_filtfilt.boundary_nan_preserved'
+            'tools.nan_filtfilt.too_short_segments_nan'
+        }
+    end
+
     methods (Test)
+        function testBiosiglibConformanceCase(tc, validConformanceCaseId)
+            tc.verifyBiosiglibNanFilteringCase( ...
+                @nanfiltfilt, validConformanceCaseId);
+        end
+
         function testNoNanSignal(tc)
             tc.verifyNoNaNSignal(@nanfiltfilt, @filtfilt);
         end

--- a/test/tools/snaptopeakTest.m
+++ b/test/tools/snaptopeakTest.m
@@ -16,11 +16,12 @@ classdef snaptopeakTest < matlab.unittest.TestCase
             'tools.snap_to_peak.boundary_clipping'
             'tools.snap_to_peak.configurable_window_small'
             'tools.snap_to_peak.configurable_window_large'
+            'tools.snap_to_peak.ecg_nan_segment_boundary'
+            'tools.snap_to_peak.detection_nan_returns_nan'
+            'tools.snap_to_peak.detection_on_nan_ecg_returns_nan'
         }
         expectedErrorCaseId = {
             'tools.snap_to_peak.invalid_detection_out_of_bounds'
-            'tools.snap_to_peak.invalid_ecg_nan'
-            'tools.snap_to_peak.invalid_detections_nan'
         }
     end
 
@@ -141,6 +142,14 @@ classdef snaptopeakTest < matlab.unittest.TestCase
                 'Large window detections should be within bounds');
         end
 
+        function testFirstMaximumWinsForTies(tc)
+            ecg = [0, 2, 1, 2, 0];
+            actual = snaptopeak(ecg, 3, 'WindowSize', 2);
+
+            tc.verifyEqual(actual, 2, ...
+                'The first maximum in the clipped search window should win ties');
+        end
+
         function testInputValidation(tc)
             [ecg, ~] = tc.loadFixtureData();
 
@@ -151,6 +160,16 @@ classdef snaptopeakTest < matlab.unittest.TestCase
             % Character detections input
             tc.verifyError(@() snaptopeak(ecg, 'invalid'), 'MATLAB:InputParser:ArgumentFailedValidation', ...
                 'Should error for character detections input');
+
+            % Infinite ECG and detection values remain invalid
+            tc.verifyError(@() snaptopeak([0, Inf, 1], 2), 'MATLAB:InputParser:ArgumentFailedValidation', ...
+                'Should error for Inf ECG input');
+            tc.verifyError(@() snaptopeak([0, -Inf, 1], 2), 'MATLAB:InputParser:ArgumentFailedValidation', ...
+                'Should error for -Inf ECG input');
+            tc.verifyError(@() snaptopeak(ecg, Inf), 'MATLAB:InputParser:ArgumentFailedValidation', ...
+                'Should error for Inf detections input');
+            tc.verifyError(@() snaptopeak(ecg, -Inf), 'MATLAB:InputParser:ArgumentFailedValidation', ...
+                'Should error for -Inf detections input');
 
             % Invalid window size
             tc.verifyError(@() snaptopeak(ecg, 100, 'WindowSize', -1), 'MATLAB:InputParser:ArgumentFailedValidation', ...

--- a/test/tools/snaptopeakTest.m
+++ b/test/tools/snaptopeakTest.m
@@ -10,16 +10,35 @@ classdef snaptopeakTest < matlab.unittest.TestCase
         fs = 256;
     end
 
+    properties (TestParameter)
+        validConformanceCaseId = {
+            'tools.snap_to_peak.local_maxima'
+            'tools.snap_to_peak.boundary_clipping'
+            'tools.snap_to_peak.configurable_window_small'
+            'tools.snap_to_peak.configurable_window_large'
+        }
+        expectedErrorCaseId = {
+            'tools.snap_to_peak.invalid_detection_out_of_bounds'
+            'tools.snap_to_peak.invalid_ecg_nan'
+            'tools.snap_to_peak.invalid_detections_nan'
+        }
+    end
+
     methods (TestClassSetup)
         function addCodeToPath(tc)
-            addpath(fullfile('..', '..', 'src', 'tools'));
-            addpath(fullfile(pwd, '..', '..', 'fixtures', 'ecg'));
+            testDirectory = fileparts(mfilename('fullpath'));
+            repositoryRoot = fileparts(fileparts(testDirectory));
+            originalPath = path;
+            tc.addTeardown(@() path(originalPath));
+            addpath(fullfile(repositoryRoot, 'src', 'tools'));
+            addpath(fullfile(repositoryRoot, 'test', 'common'));
+            addpath(fullfile(repositoryRoot, 'fixtures', 'ecg'));
 
             % Verify functions are available
             tc.verifyTrue(~isempty(which('snaptopeak')), 'snaptopeak function not found in path');
 
             % Check fixture files exist
-            fixturesPath = fullfile(pwd, '..', '..', 'fixtures', 'ecg');
+            fixturesPath = fullfile(repositoryRoot, 'fixtures', 'ecg');
             tc.verifyTrue(exist(fullfile(fixturesPath, 'medicom_mtd_ecg_respiration.csv'), 'file') > 0, ...
                 'medicom_mtd_ecg_respiration.csv not found in fixtures path');
             tc.verifyTrue(exist(fullfile(fixturesPath, 'medicom_mtd_r_wave_timing.csv'), 'file') > 0, ...
@@ -29,7 +48,9 @@ classdef snaptopeakTest < matlab.unittest.TestCase
 
     methods (Access = private)
         function fixturesPath = getFixturesPath(~)
-            fixturesPath = fullfile(pwd, '..', '..', 'fixtures', 'ecg');
+            testDirectory = fileparts(mfilename('fullpath'));
+            repositoryRoot = fileparts(fileparts(testDirectory));
+            fixturesPath = fullfile(repositoryRoot, 'fixtures', 'ecg');
         end
 
         function [ecg, tkSamples] = loadFixtureData(tc)
@@ -44,9 +65,38 @@ classdef snaptopeakTest < matlab.unittest.TestCase
             % Convert time-based detections to sample indices
             tkSamples = peaksData.r_wave_samples(:);
         end
+
+        function refinedDetections = callSnaptopeakFromCase(~, caseDefinition)
+            ecg = loadBiosiglibConformanceInput(caseDefinition, 'ecg');
+            detections = loadBiosiglibConformanceInput(caseDefinition, 'detections');
+
+            if isfield(caseDefinition, 'parameters') && ...
+                    isfield(caseDefinition.parameters, 'window_size')
+                refinedDetections = snaptopeak( ...
+                    ecg, detections, 'WindowSize', caseDefinition.parameters.window_size);
+            else
+                refinedDetections = snaptopeak(ecg, detections);
+            end
+        end
     end
 
     methods (Test)
+        function testBiosiglibConformanceCase(tc, validConformanceCaseId)
+            caseDefinition = loadBiosiglibConformanceCase(validConformanceCaseId);
+
+            refinedDetections = tc.callSnaptopeakFromCase(caseDefinition);
+
+            actualOutputs = struct('refined_detections', refinedDetections);
+            verifyBiosiglibExpectedOutputs(tc, actualOutputs, caseDefinition);
+        end
+
+        function testBiosiglibExpectedError(tc, expectedErrorCaseId)
+            caseDefinition = loadBiosiglibConformanceCase(expectedErrorCaseId);
+
+            verifyBiosiglibExpectedError(tc, ...
+                @() tc.callSnaptopeakFromCase(caseDefinition), caseDefinition);
+        end
+
         function testPeakRefinementAccuracy(tc)
             [ecg, originalDetections] = tc.loadFixtureData();
 


### PR DESCRIPTION
﻿## Summary
- Pins conformance to Biosiglib v0.5.5 (`9844bd742d6c375f472dceb16adaae97e700509b`). As of this update, `origin/main` still points to Biosiglib v0.5.4, so the postrelease propagation has not landed on `main` yet.
- Implements the NaN-aware `snaptopeak` behavior: NaN ECG gaps are hard finite-segment boundaries, NaN detections keep output alignment as NaN, detections on NaN ECG samples return NaN, and Inf/-Inf remain invalid.
- Simplifies `pantompkins` back to delegating segment refinement to `snaptopeak`.
- Updates `snaptopeak` conformance coverage for the new Biosiglib cases.

## Conformance Cases
- `tools.snap_to_peak.ecg_nan_segment_boundary`
- `tools.snap_to_peak.detection_nan_returns_nan`
- `tools.snap_to_peak.detection_on_nan_ecg_returns_nan`

## Validation
- `matlab -batch "addpath('scripts/local'); runTests('tools/snaptopeak'); runTests('ecg/pantompkins')"`
- `matlab -batch "addpath('scripts/local'); runTests('tools/medfiltThreshold'); runTests('tools/nanfilter'); runTests('tools/nanfiltfilt'); runTests('tools/lpdfilter'); runTests('tools/snaptopeak')"`
- `matlab -batch "addpath('scripts/local'); runTests"` (188/188 passed)
- `.venv\Scripts\python.exe tools\validate_specs.py --manifest C:\Users\cajal\dev\biosig\biosigmat\conformance.json`
- `git diff --check`
